### PR TITLE
Adding logic to detect if port changes actually took effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Second, ensure the [Gluetun](https://github.com/qdm12/gluetun/) control server p
 Finally, insert the template in `docker-compose.yml` into your docker-compose containing gluetun, substituting the default values for your own.
 
 ## NOTE
-This currently only works with OpenVPN.  This has been a relatively personal project for my stack after seeing a number of people talk about running bash scripts on their Docker host to keep the dreaded firewall warning away.  I found [snoringdragon's](https://github.com/SnoringDragon)  repo and decided it would be a fun way to learn to build and push a real Docker image, and also learn some basics in GitHub along the way.  
+This has been a relatively personal project for my stack after seeing a number of people talk about running bash scripts on their Docker host to keep the dreaded firewall warning away.  I found [snoringdragon's](https://github.com/SnoringDragon)  repo and decided it would be a fun way to learn to build and push a real Docker image, and also learn some basics in GitHub along the way.  

--- a/start.sh
+++ b/start.sh
@@ -19,16 +19,20 @@ update_port () {
 
   # Update qbittorrent preferences with the new port
   curl -s -b "$COOKIES" --data "json={\"listen_port\": \"$PORT\"}" "${HTTP_S}://${QBITTORRENT_SERVER}:${QBITTORRENT_PORT}/api/v2/app/setPreferences" > /dev/null
-  if [[ $? -ne 0 ]]; then
+
+  # Check current port to see if changes took effect
+  CURRENT_PORT=$(curl -s -b $COOKIES ${HTTP_S}://${QBITTORRENT_SERVER}:${QBITTORRENT_PORT}/api/v2/app/preferences | jq -r '.listen_port')
+  
+  if [ "$CURRENT_PORT" == "$PORT" ]; then
+    echo "Successfully updated qbittorrent to port $PORT"
+    break
+  else
     echo "Failed to update port."
     return 1
   fi
-
+  
   # Clean up cookies file
   rm -f "$COOKIES"
-
-  # Update CURRENT_PORT to the new value
-  CURRENT_PORT="$PORT"
 
   echo "Successfully updated qbittorrent to port $PORT"
 }


### PR DESCRIPTION
As mentioned on #6, the script will always exit with 0 as long as the API responds, not actually detecting whether the port change was actually picked up by qbit's API server. This simple check returns a 0 exit code in cases where it is not able to update the port, no longer erroring silently. 